### PR TITLE
Add peck attack in the lobby

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A multiplayer chicken-themed runner game for up to 6 players to race and jump ov
 - **Arrow keys** - move
 - **Space** - jump / glide
 - **V** - cluck
+- **X** - peck (lobby only)
 - **T** - chat
 
 ## Self-hosting

--- a/src/js/engine/input.js
+++ b/src/js/engine/input.js
@@ -9,6 +9,7 @@ const KEY_MAP = {
   KeyS: "down",
   Space: "jump",
   KeyV: "cluck",
+  KeyX: "peck",
 };
 
 export class InputManager {

--- a/src/js/engine/network.js
+++ b/src/js/engine/network.js
@@ -16,6 +16,7 @@ export class NetworkManager {
     this.onStart = null;
     this.onChat = null;
     this.onScore = null;
+    this.onPeck = null;
   }
 
   /**
@@ -79,6 +80,9 @@ export class NetworkManager {
           break;
         case "score":
           this.onScore?.(data.id, data.total, data.lastRun);
+          break;
+        case "peck":
+          this.onPeck?.(data.id, data.x, data.y, data.facingRight);
           break;
       }
     };
@@ -160,6 +164,17 @@ export class NetworkManager {
   sendScore(total, lastRun) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
     this.ws.send(JSON.stringify({ type: "score", total, lastRun }));
+  }
+
+  /**
+   * Broadcast a peck attack from the local chicken.
+   * @param {number} x
+   * @param {number} y
+   * @param {boolean} facingRight
+   */
+  sendPeck(x, y, facingRight) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ type: "peck", x, y, facingRight }));
   }
 
   sendCustomize(spriteSet, colorIndex, name) {

--- a/src/js/entities/base-chicken.js
+++ b/src/js/entities/base-chicken.js
@@ -20,6 +20,9 @@ export class BaseChicken {
     this.isJumping = false;
     this.isGliding = false;
     this.isClucking = false;
+    this.isPecking = false;
+    this.peckTimer = 0;
+    this.knockbackVX = 0;
 
     this.currentFrame = 0;
     this.cluckFrame = 0;
@@ -96,6 +99,18 @@ export class BaseChicken {
     const drawY = this.y + this.airY;
 
     drawTintedSprite(ctx, set.spriteSheet, frameX, frameY, this.spriteWidth, this.spriteHeight, this.x, drawY, drawWidth, drawHeight, this.facingRight, this.tint, this.opacity);
+
+    // peck indicator — small jab in the facing direction
+    if (this.isPecking) {
+      const reach = 18;
+      const beakY = drawY + drawHeight * 0.45;
+      const beakX = this.facingRight ? this.x + drawWidth : this.x - reach;
+      ctx.save();
+      ctx.globalAlpha = this.opacity;
+      ctx.fillStyle = "#ffcf3f";
+      ctx.fillRect(beakX, beakY, reach, 4);
+      ctx.restore();
+    }
 
     // cluck bubble — decorative only, excluded from collision
     if (this.isClucking) {

--- a/src/js/entities/chicken.js
+++ b/src/js/entities/chicken.js
@@ -49,6 +49,11 @@ export class Chicken extends BaseChicken {
 
     // when true, chicken always faces right and plays run animation
     this.autoRun = false;
+
+    // peck
+    this.peckCooldown = 0;
+    this.peckDuration = 8;
+    this.peckTriggered = false;
   }
 
   /**
@@ -138,8 +143,27 @@ export class Chicken extends BaseChicken {
       }
     }
 
+    // peck
+    if (this.peckCooldown > 0) this.peckCooldown--;
+    if (this.input.isDown("peck") && this.peckCooldown === 0 && !this.isJumping) {
+      this.isPecking = true;
+      this.peckTimer = this.peckDuration;
+      this.peckCooldown = 25;
+      this.peckTriggered = true;
+    }
+    if (this.isPecking) {
+      this.peckTimer--;
+      if (this.peckTimer <= 0) this.isPecking = false;
+    }
+
+    // knockback decay
+    if (this.knockbackVX !== 0) {
+      this.knockbackVX *= 0.85;
+      if (Math.abs(this.knockbackVX) < 0.1) this.knockbackVX = 0;
+    }
+
     // move and clamp
-    this.x += this.velocityX;
+    this.x += this.velocityX + this.knockbackVX;
 
     if (this.isJumping) {
       this.airY += this.velocityY;

--- a/src/js/entities/remote-chicken.js
+++ b/src/js/entities/remote-chicken.js
@@ -77,5 +77,10 @@ export class RemoteChicken extends BaseChicken {
     this.x = lerp(this.x, this.targetX, LERP_SPEED);
     this.y = lerp(this.y, this.targetY, LERP_SPEED);
     this.airY = lerp(this.airY, this.targetAirY, LERP_SPEED);
+
+    if (this.isPecking) {
+      this.peckTimer--;
+      if (this.peckTimer <= 0) this.isPecking = false;
+    }
   }
 }

--- a/src/js/scenes/lobby-scene.js
+++ b/src/js/scenes/lobby-scene.js
@@ -73,6 +73,18 @@ export class LobbyScene extends BaseScene {
       this.startRunnerScene(roundSeed);
     };
 
+    this.network.onPeck = (id, x, y, facingRight) => {
+      const remote = this.networkSync.remoteChickens.get(id);
+      if (remote) {
+        remote.isPecking = true;
+        remote.peckTimer = 8;
+      }
+      // victim check: did this peck hit our local chicken?
+      if (this.chickenHit(x, y, facingRight, this.chicken)) {
+        this.chicken.knockbackVX = facingRight ? 9 : -9;
+      }
+    };
+
     this.origOnJoin = this.network.onJoin;
     this.network.onJoin = (id, colorIndex, spriteSet, name) => {
       this.origOnJoin?.(id, colorIndex, spriteSet, name);
@@ -105,6 +117,22 @@ export class LobbyScene extends BaseScene {
     window.addEventListener("keydown", this.onKeyDown);
   }
 
+  /** Returns true if a peck from (attackerX, attackerY) facing the given direction overlaps the victim. */
+  chickenHit(attackerX, attackerY, facingRight, victim) {
+    const reach = 18;
+    const attackerW = 60;
+    const hitX = facingRight ? attackerX + attackerW : attackerX - reach;
+    const hitY = attackerY + 10;
+    const hitW = reach;
+    const hitH = 40;
+    return (
+      hitX < victim.x + victim.width &&
+      hitX + hitW > victim.x &&
+      hitY < victim.y + victim.height &&
+      hitY + hitH > victim.y
+    );
+  }
+
   /** @param {number} roundSeed */
   startRunnerScene(roundSeed) {
     const runner = new RunnerScene(this.context);
@@ -119,6 +147,12 @@ export class LobbyScene extends BaseScene {
   update(dt) {
     this.cloudLayer.update();
     this.chicken.update(dt);
+
+    if (this.chicken.peckTriggered) {
+      this.chicken.peckTriggered = false;
+      this.network.sendPeck(this.chicken.x, this.chicken.y, this.chicken.facingRight);
+    }
+
     this.networkSync.update(this.chicken, dt);
     this.updateChat([this.chicken, ...this.networkSync.getRemoteChickens()], dt);
 
@@ -248,6 +282,7 @@ export class LobbyScene extends BaseScene {
   exit() {
     this.network.onReady = null;
     this.network.onStart = null;
+    this.network.onPeck = null;
     this.network.onId = this.origOnId;
     this.network.onJoin = this.origOnJoin;
     this.network.onLeave = this.origOnLeave;


### PR DESCRIPTION
## Summary
- Press **X** in the lobby to peck in your facing direction; a small yellow beak-jab renders for ~8 frames
- Pecks knock back any chicken whose AABB overlaps the hitbox; victim-authoritative (each client checks incoming peck events against their own chicken and applies knockback to themselves)
- Restricted to the lobby — the runner scene's `InputFilter` already strips the peck action, so racing is unaffected
- New `peck` network message type passes through the existing broadcast logic in `ws.ts` without server changes

## Test plan
- [ ] Open two browser tabs in the same lobby, press **X**, verify the yellow jab appears on both tabs
- [ ] Position chickens so one is in front of the other and confirm the front chicken gets knocked back
- [ ] Hold **X** and confirm the ~25-frame cooldown rate-limits pecks
- [ ] Try pecking mid-jump — should be disabled
- [ ] Start a race and confirm pressing X does nothing in the runner scene

---
_Generated by [Claude Code](https://claude.ai/code/session_017QHDoE2q7qMn5tW54kmctp)_